### PR TITLE
#34 수집 재조회 스케줄러 위임 및 헥사고날 계층 정리

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,7 +85,7 @@ domain/                Aggregate 단위 모듈 (entity + repo + JPA/QueryDSL + C
   user-feature         UserFeatureGrant, UserModuleDisplay, UserFeatureDisplay
   market               MarketType, Exchange, ExchangeTradingDate, MarketListingSync
   stock                Stock, StockDetail, StockEvent(권리이벤트), StockPrice, StockTagValue
-  stock-collection     KIS 주가/권리이벤트(KSD) 수집 코어 + 백필 런처(CollectionLauncher, CollectionTask)
+  stock-collection     KIS 주가/KSD 권리이벤트 수집 코어 + KRX 종목 동기화(StockSyncService) + TradingDayPort(KRX 포트) + 수집 태스크(CollectionLauncher, CollectionTask)
   indicator            TechnicalIndicator + 지표 계산기 + IndicatorCursor(+CAS)
   investor-flow        InvestorDaily (기관·외국인·개인 매매동향)
   system-event         수집·계산 운영 이벤트(KRX/KIS 실패 등) — ROOT 모니터링

--- a/application/api/build.gradle
+++ b/application/api/build.gradle
@@ -16,13 +16,11 @@ dependencies {
     implementation project(":indicator")
     implementation project(":auth")
     implementation project(":user")
-    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation project(":screening")
     implementation project(":user-feature")
     implementation project(":system-event")
     implementation project(":api-quota")
     implementation project(":stock-collection")
-    implementation project(":kis")
     implementation project(":job-status")
     implementation project(":investor-flow")
 
@@ -30,12 +28,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 
     testImplementation project(':jpa')
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
     testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.redisson:redisson:3.27.2'
 }
 
 dependencyManagement {

--- a/application/api/src/main/java/com/dove/api/ops/collection/controller/CollectionController.java
+++ b/application/api/src/main/java/com/dove/api/ops/collection/controller/CollectionController.java
@@ -53,7 +53,7 @@ public class CollectionController {
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_EXCHANGE");
         }
-        Long taskId = launcher.launchPriceCollection(exchange, req.from(), req.to(), req.adjustedFrom(), user.memberId());
+        Long taskId = launcher.enqueuePriceCollection(exchange, req.from(), req.to(), user.memberId());
         return Map.of("taskId", taskId);
     }
 
@@ -64,7 +64,7 @@ public class CollectionController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public Map<String, Long> collectEvent(@Valid @RequestBody EventCollectionRequest req,
                                           @AuthenticationPrincipal AuthenticatedUser user) {
-        Long taskId = launcher.launchEventCollection(req.from(), req.to(), user.memberId());
+        Long taskId = launcher.enqueueEventCollection(req.from(), req.to(), user.memberId());
         return Map.of("taskId", taskId);
     }
 
@@ -75,7 +75,7 @@ public class CollectionController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public Map<String, Long> collectStock(@Valid @RequestBody StockCollectionRequest req,
                                           @AuthenticationPrincipal AuthenticatedUser user) {
-        Long taskId = launcher.launchStockCollection(req.from(), req.to(), user.memberId());
+        Long taskId = launcher.enqueueStockCollection(req.from(), req.to(), user.memberId());
         return Map.of("taskId", taskId);
     }
 
@@ -86,7 +86,7 @@ public class CollectionController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public Map<String, Long> collectInvestor(@Valid @RequestBody InvestorCollectionRequest req,
                                              @AuthenticationPrincipal AuthenticatedUser user) {
-        Long taskId = launcher.launchInvestorCollection(req.from(), req.to(), user.memberId());
+        Long taskId = launcher.enqueueInvestorCollection(req.from(), req.to(), user.memberId());
         return Map.of("taskId", taskId);
     }
 
@@ -118,7 +118,7 @@ public class CollectionController {
         if (taskService.find(id).isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "TASK_NOT_FOUND");
         }
-        Long newTaskId = launcher.relaunch(id, user.memberId());
+        Long newTaskId = launcher.reenqueue(id, user.memberId());
         return Map.of("taskId", newTaskId);
     }
 }

--- a/application/api/src/main/java/com/dove/api/ops/collection/dto/PriceCollectionRequest.java
+++ b/application/api/src/main/java/com/dove/api/ops/collection/dto/PriceCollectionRequest.java
@@ -6,17 +6,13 @@ import java.time.LocalDate;
 
 /**
  * 주가 재조회 요청.
+ *
+ * @param exchange KOSPI/KOSDAQ/KONEX/NXT/INTEGRATED
+ * @param from     수집 시작일
+ * @param to       수집 종료일
  */
 public record PriceCollectionRequest(
-        @NotNull String exchange,   // KOSPI/KOSDAQ/KONEX/NXT/INTEGRATED
+        @NotNull String exchange,
         @NotNull LocalDate from,
-        @NotNull LocalDate to,
-        Integer adjustedFromYear    // 수정주가 재조회 시작 연도. null이면 재조회 안 함.
-) {
-    /**
-     * 수정주가 재조회 하한 날짜. null이면 재조회 생략.
-     */
-    public LocalDate adjustedFrom() {
-        return adjustedFromYear == null ? null : LocalDate.of(adjustedFromYear, 1, 1);
-    }
-}
+        @NotNull LocalDate to
+) {}

--- a/application/api/src/test/java/com/dove/api/TestApiApplication.java
+++ b/application/api/src/test/java/com/dove/api/TestApiApplication.java
@@ -1,7 +1,56 @@
 package com.dove.api;
 
+import com.dove.stockcollection.application.port.AnalystFetcher;
+import com.dove.stockcollection.application.port.DailyPriceFetcher;
+import com.dove.stockcollection.application.port.InvestorFetcher;
+import com.dove.stockcollection.application.port.KsdEventFetcher;
+import com.dove.stockcollection.application.port.TradingDayPort;
+import org.redisson.api.RRateLimiter;
+import org.redisson.api.RedissonClient;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SpringBootApplication(scanBasePackages = "com.dove")
+@Import(TestApiApplication.TestInfraConfig.class)
 public class TestApiApplication {
+
+    /**
+     * 외부 시스템(Redis, KIS, KRX) 의존 빈을 mock으로 교체한다.
+     */
+    @TestConfiguration
+    static class TestInfraConfig {
+
+        @Bean
+        public RedissonClient redissonClient() {
+            RedissonClient redisson = mock(RedissonClient.class);
+            when(redisson.getRateLimiter(anyString())).thenReturn(mock(RRateLimiter.class));
+            return redisson;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Bean
+        public StringRedisTemplate stringRedisTemplate() {
+            StringRedisTemplate template = mock(StringRedisTemplate.class);
+            ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+            when(template.opsForValue()).thenReturn(valueOps);
+            HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
+            when(template.opsForHash()).thenReturn(hashOps);
+            return template;
+        }
+
+        @Bean public DailyPriceFetcher dailyPriceFetcher() { return mock(DailyPriceFetcher.class); }
+        @Bean public KsdEventFetcher ksdEventFetcher() { return mock(KsdEventFetcher.class); }
+        @Bean public AnalystFetcher analystFetcher() { return mock(AnalystFetcher.class); }
+        @Bean public InvestorFetcher investorFetcher() { return mock(InvestorFetcher.class); }
+        @Bean public TradingDayPort tradingDayPort() { return mock(TradingDayPort.class); }
+    }
 }

--- a/application/api/src/test/java/com/dove/api/ops/collection/controller/CollectionControllerTest.java
+++ b/application/api/src/test/java/com/dove/api/ops/collection/controller/CollectionControllerTest.java
@@ -46,12 +46,12 @@ class CollectionControllerTest {
 
     @BeforeEach
     void setUp() {
-        given(launcher.launchPriceCollection(any(StockExchange.class), any(), any(), any(), anyLong()))
+        given(launcher.enqueuePriceCollection(any(StockExchange.class), any(), any(), anyLong()))
                 .willReturn(11L);
-        given(launcher.launchEventCollection(any(), any(), anyLong())).willReturn(22L);
-        given(launcher.launchStockCollection(any(), any(), anyLong())).willReturn(33L);
-        given(launcher.launchInvestorCollection(any(), any(), anyLong())).willReturn(55L);
-        given(launcher.relaunch(anyLong(), anyLong())).willReturn(44L);
+        given(launcher.enqueueEventCollection(any(), any(), anyLong())).willReturn(22L);
+        given(launcher.enqueueStockCollection(any(), any(), anyLong())).willReturn(33L);
+        given(launcher.enqueueInvestorCollection(any(), any(), anyLong())).willReturn(55L);
+        given(launcher.reenqueue(anyLong(), anyLong())).willReturn(44L);
 
         CollectionTask task = new CollectionTask(CollectionType.PRICE, StockExchange.KOSPI,
                 LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31), 1L);

--- a/application/api/src/test/resources/application.yml
+++ b/application/api/src/test/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   mvc:
     problemdetails:
       enabled: true
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver
@@ -18,3 +22,8 @@ jwt:
   secret: test-secret-key-minimum-32-characters-long!!
   access-expiration-ms: 900000
   refresh-expiration-ms: 2592000000
+
+krx:
+  api:
+    quota:
+      enabled: false

--- a/application/scheduler/src/main/java/com/dove/scheduler/job/PendingCollectionJob.java
+++ b/application/scheduler/src/main/java/com/dove/scheduler/job/PendingCollectionJob.java
@@ -1,0 +1,67 @@
+package com.dove.scheduler.job;
+
+import com.dove.stockcollection.application.service.CollectionLauncher;
+import com.dove.stockcollection.application.service.CollectionTaskService;
+import com.dove.stockcollection.domain.enums.CollectionType;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * PENDING 재조회 태스크를 폴링하여 KRX·KIS 트랙으로 분리 실행하는 잡.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PendingCollectionJob {
+
+    private static final List<CollectionType> KRX_TYPES = List.of(CollectionType.STOCK);
+    private static final List<CollectionType> KIS_TYPES = List.of(
+            CollectionType.PRICE, CollectionType.EVENT, CollectionType.INVESTOR);
+
+    private final CollectionLauncher launcher;
+    private final CollectionTaskService taskService;
+
+    private final ExecutorService background = Executors.newVirtualThreadPerTaskExecutor();
+
+    /**
+     * 기동 시 RUNNING 상태로 남은 태스크를 FAILED로 전환한다(강제 종료 복구).
+     */
+    @PostConstruct
+    void recoverStaleRunning() {
+        taskService.failStaleRunning();
+    }
+
+    /**
+     * 30초마다 PENDING 태스크를 확인하여 KRX·KIS 트랙 각각 하나씩 실행한다.
+     * 이미 같은 트랙이 RUNNING 중이면 해당 트랙은 건너뛴다.
+     */
+    @Scheduled(fixedDelay = 30_000)
+    public void poll() {
+        if (!taskService.hasRunning(KRX_TYPES)) {
+            taskService.findOldestPending(KRX_TYPES).ifPresent(task -> {
+                log.info("KRX 트랙 태스크 실행: id={} type={} {}~{}", task.getId(), task.getType(), task.getFromDate(), task.getToDate());
+                background.execute(() -> launcher.executeTask(task));
+            });
+        }
+
+        if (!taskService.hasRunning(KIS_TYPES)) {
+            taskService.findOldestPending(KIS_TYPES).ifPresent(task -> {
+                log.info("KIS 트랙 태스크 실행: id={} type={} {}~{}", task.getId(), task.getType(), task.getFromDate(), task.getToDate());
+                background.execute(() -> launcher.executeTask(task));
+            });
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        background.shutdown();
+    }
+}

--- a/application/scheduler/src/main/java/com/dove/scheduler/job/StockSyncJob.java
+++ b/application/scheduler/src/main/java/com/dove/scheduler/job/StockSyncJob.java
@@ -3,7 +3,7 @@ package com.dove.scheduler.job;
 import com.dove.jobstatus.JobStatusRegistry;
 import com.dove.market.domain.enums.MarketType;
 import com.dove.jobstatus.SchedulerJobName;
-import com.dove.scheduler.service.StockSyncService;
+import com.dove.stockcollection.application.service.StockSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/application/scheduler/src/test/java/com/dove/scheduler/job/StockSyncJobTest.java
+++ b/application/scheduler/src/test/java/com/dove/scheduler/job/StockSyncJobTest.java
@@ -3,7 +3,7 @@ package com.dove.scheduler.job;
 import com.dove.jobstatus.JobStatusRegistry;
 import com.dove.jobstatus.SchedulerJobName;
 import com.dove.market.domain.enums.MarketType;
-import com.dove.scheduler.service.StockSyncService;
+import com.dove.stockcollection.application.service.StockSyncService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/domain/stock-collection/build.gradle
+++ b/domain/stock-collection/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     implementation project(':market')
     implementation project(':stock')
     implementation project(':indicator')
-    implementation project(':krx')
     implementation project(':concurrent')
     implementation project(':datetime')
     implementation project(':system-event')

--- a/domain/stock-collection/src/main/java/com/dove/stockcollection/application/port/StockListing.java
+++ b/domain/stock-collection/src/main/java/com/dove/stockcollection/application/port/StockListing.java
@@ -1,4 +1,4 @@
-package com.dove.krx;
+package com.dove.stockcollection.application.port;
 
 import java.time.LocalDate;
 

--- a/domain/stock-collection/src/main/java/com/dove/stockcollection/application/port/TradingDayPort.java
+++ b/domain/stock-collection/src/main/java/com/dove/stockcollection/application/port/TradingDayPort.java
@@ -1,4 +1,4 @@
-package com.dove.krx;
+package com.dove.stockcollection.application.port;
 
 import com.dove.market.domain.enums.MarketType;
 
@@ -9,6 +9,7 @@ import java.util.List;
  * KRX 상장 종목 조회 포트.
  */
 public interface TradingDayPort {
+
     /**
      * 해당 날짜의 KRX 상장 종목 목록을 조회한다.
      * 데이터가 없는 날짜(미래·API 미제공·오류)는 빈 리스트를 반환한다.

--- a/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/CollectionLauncher.java
+++ b/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/CollectionLauncher.java
@@ -5,18 +5,15 @@ import com.dove.stock.domain.enums.StockExchange;
 import com.dove.stockcollection.application.port.DailyPriceFetcher;
 import com.dove.stockcollection.domain.entity.CollectionTask;
 import com.dove.stockcollection.domain.enums.CollectionType;
-import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
- * 수집 작업을 백그라운드로 띄우는 진입점.
+ * 수집 태스크 생성(enqueue)과 실행(execute)을 제공하는 진입점.
  */
 @Slf4j
 @Service
@@ -30,83 +27,82 @@ public class CollectionLauncher {
     private final CollectionTaskService taskService;
     private final Clock clock;
 
-    private final ExecutorService background = Executors.newVirtualThreadPerTaskExecutor();
-
     /**
-     * 컨텍스트 종료 시 백그라운드 실행기를 닫는다(진행 중 작업 완료 후 정리).
-     */
-    @PreDestroy
-    void shutdown() {
-        background.shutdown();
-    }
-
-    /**
-     * 주가 재조회를 백그라운드로 시작하고 작업ID를 반환한다.
-     * 재조회는 어제까지로 제한한다(오늘은 일일 수집 잡 전담 → 두 경로가 같은 날짜를 안 건드림).
+     * 주가 재조회 태스크를 PENDING으로 등록하고 작업ID를 반환한다.
+     * 재조회는 어제까지로 제한한다.
      *
      * @throws IllegalArgumentException 요청 범위 전체가 오늘 이후인 경우 (INVALID_BACKFILL_RANGE)
      */
-    public Long launchPriceCollection(StockExchange exchange, LocalDate from, LocalDate to,
-                                      LocalDate adjustedFrom, Long requestedBy) {
+    public Long enqueuePriceCollection(StockExchange exchange, LocalDate from, LocalDate to, Long requestedBy) {
         LocalDate yesterday = LocalDate.now(clock).minusDays(1);
         LocalDate cappedTo = to.isAfter(yesterday) ? yesterday : to;
         if (from.isAfter(cappedTo)) throw new IllegalArgumentException("INVALID_BACKFILL_RANGE");
-
-        Long taskId = taskService.create(CollectionType.PRICE, exchange, from, cappedTo, requestedBy);
-        background.execute(() -> runGuarded(taskId, () ->
-                priceCollectionService.collect(exchange, from, cappedTo, new TaskProgress(taskService, taskId), adjustedFrom)));
-        return taskId;
+        return taskService.create(CollectionType.PRICE, exchange, from, cappedTo, requestedBy);
     }
 
     /**
-     * 권리 이벤트(KSD) 재조회를 백그라운드로 시작하고 작업ID를 반환한다.
+     * 권리 이벤트(KSD) 재조회 태스크를 PENDING으로 등록하고 작업ID를 반환한다.
+     *
+     * @throws IllegalArgumentException 날짜 범위가 역순인 경우 (INVALID_BACKFILL_RANGE)
      */
-    public Long launchEventCollection(LocalDate from, LocalDate to, Long requestedBy) {
+    public Long enqueueEventCollection(LocalDate from, LocalDate to, Long requestedBy) {
         if (from.isAfter(to)) throw new IllegalArgumentException("INVALID_BACKFILL_RANGE");
-        Long taskId = taskService.create(CollectionType.EVENT, null, from, to, requestedBy);
-        background.execute(() -> runGuarded(taskId, () ->
-                eventCollectionService.collect(from, to, new TaskProgress(taskService, taskId))));
-        return taskId;
+        return taskService.create(CollectionType.EVENT, null, from, to, requestedBy);
     }
 
     /**
-     * 종목 재조회를 백그라운드로 시작하고 작업ID를 반환한다.
+     * 종목 재조회 태스크를 PENDING으로 등록하고 작업ID를 반환한다.
+     *
+     * @throws IllegalArgumentException 날짜 범위가 역순인 경우 (INVALID_BACKFILL_RANGE)
      */
-    public Long launchStockCollection(LocalDate from, LocalDate to, Long requestedBy) {
+    public Long enqueueStockCollection(LocalDate from, LocalDate to, Long requestedBy) {
         if (from.isAfter(to)) throw new IllegalArgumentException("INVALID_BACKFILL_RANGE");
-        Long taskId = taskService.create(CollectionType.STOCK, null, from, to, requestedBy);
-        background.execute(() -> runGuarded(taskId, () ->
-                stockCollectionService.collect(from, to, new TaskProgress(taskService, taskId))));
-        return taskId;
+        return taskService.create(CollectionType.STOCK, null, from, to, requestedBy);
     }
 
     /**
-     * 투자자매매동향 재조회를 백그라운드로 시작하고 작업ID를 반환한다.
+     * 투자자매매동향 재조회 태스크를 PENDING으로 등록하고 작업ID를 반환한다.
+     *
+     * @throws IllegalArgumentException 날짜 범위가 역순인 경우 (INVALID_BACKFILL_RANGE)
      */
-    public Long launchInvestorCollection(LocalDate from, LocalDate to, Long requestedBy) {
+    public Long enqueueInvestorCollection(LocalDate from, LocalDate to, Long requestedBy) {
         if (from.isAfter(to)) throw new IllegalArgumentException("INVALID_BACKFILL_RANGE");
-        Long taskId = taskService.create(CollectionType.INVESTOR, null, from, to, requestedBy);
-        background.execute(() -> runGuarded(taskId, () ->
-                investorCollectionService.collect(from, to, new TaskProgress(taskService, taskId))));
-        return taskId;
+        return taskService.create(CollectionType.INVESTOR, null, from, to, requestedBy);
     }
 
     /**
-     * 실패한(또는 임의의) 작업을 같은 범위로 다시 실행한다.
+     * 실패한 태스크를 같은 범위로 다시 PENDING 등록하고 새 작업ID를 반환한다.
+     *
+     * @throws IllegalArgumentException 원본 태스크가 없는 경우 (TASK_NOT_FOUND)
      */
-    public Long relaunch(Long sourceTaskId, Long requestedBy) {
+    public Long reenqueue(Long sourceTaskId, Long requestedBy) {
         CollectionTask source = taskService.find(sourceTaskId)
                 .orElseThrow(() -> new IllegalArgumentException("TASK_NOT_FOUND"));
         LocalDate from = source.getFromDate();
         LocalDate to = source.getToDate();
         return switch (source.getType()) {
-            // 재시도는 정확성 우선 — 전체 ADJUSTED 재조회.
-            case PRICE -> launchPriceCollection(source.getExchange(), from, to,
-                    DailyPriceFetcher.ADJUSTED_DATA_START, requestedBy);
-            case STOCK -> launchStockCollection(from, to, requestedBy);
-            case EVENT -> launchEventCollection(from, to, requestedBy);
-            case INVESTOR -> launchInvestorCollection(from, to, requestedBy);
+            case PRICE -> enqueuePriceCollection(source.getExchange(), from, to, requestedBy);
+            case STOCK -> enqueueStockCollection(from, to, requestedBy);
+            case EVENT -> enqueueEventCollection(from, to, requestedBy);
+            case INVESTOR -> enqueueInvestorCollection(from, to, requestedBy);
         };
+    }
+
+    /**
+     * PENDING 태스크를 동기적으로 실행한다. 호출자(스케줄러)가 스레드를 제공한다.
+     */
+    public void executeTask(CollectionTask task) {
+        runGuarded(task.getId(), () -> {
+            CollectionProgress progress = new TaskProgress(taskService, task.getId());
+            switch (task.getType()) {
+                case PRICE -> priceCollectionService.collect(
+                        task.getExchange(), task.getFromDate(), task.getToDate(),
+                        progress, DailyPriceFetcher.ADJUSTED_DATA_START);
+                case STOCK -> stockCollectionService.collect(task.getFromDate(), task.getToDate(), progress);
+                case EVENT -> eventCollectionService.collect(task.getFromDate(), task.getToDate(), progress);
+                case INVESTOR -> investorCollectionService.collect(task.getFromDate(), task.getToDate(), progress);
+            }
+        });
     }
 
     private void runGuarded(Long taskId, Runnable work) {

--- a/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/CollectionTaskService.java
+++ b/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/CollectionTaskService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -82,5 +83,30 @@ public class CollectionTaskService {
     @Transactional(readOnly = true)
     public Page<CollectionTask> findByStatus(CollectionStatus status, Pageable pageable) {
         return repository.findByStatus(status, pageable);
+    }
+
+    /**
+     * 지정한 유형 중 가장 오래된 PENDING 태스크를 반환한다.
+     */
+    @Transactional(readOnly = true)
+    public Optional<CollectionTask> findOldestPending(List<CollectionType> types) {
+        return repository.findFirstByTypeInAndStatusOrderByCreatedAtAsc(types, CollectionStatus.PENDING);
+    }
+
+    /**
+     * 지정한 유형 중 RUNNING 태스크가 있는지 확인한다.
+     */
+    @Transactional(readOnly = true)
+    public boolean hasRunning(List<CollectionType> types) {
+        return repository.existsByTypeInAndStatus(types, CollectionStatus.RUNNING);
+    }
+
+    /**
+     * 기동 시점에 RUNNING 상태로 남은 태스크를 FAILED로 전환한다.
+     */
+    @Transactional
+    public void failStaleRunning() {
+        repository.findAllByStatus(CollectionStatus.RUNNING)
+                .forEach(t -> t.fail("INTERRUPTED", "스케줄러 재기동으로 중단"));
     }
 }

--- a/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/StockCollectionService.java
+++ b/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/StockCollectionService.java
@@ -1,7 +1,7 @@
 package com.dove.stockcollection.application.service;
 
-import com.dove.krx.StockListing;
-import com.dove.krx.TradingDayPort;
+import com.dove.stockcollection.application.port.StockListing;
+import com.dove.stockcollection.application.port.TradingDayPort;
 import com.dove.market.domain.enums.MarketType;
 import com.dove.stock.application.service.StockCommandService;
 import com.dove.stock.domain.entity.Stock;

--- a/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/StockSyncService.java
+++ b/domain/stock-collection/src/main/java/com/dove/stockcollection/application/service/StockSyncService.java
@@ -1,12 +1,12 @@
-package com.dove.scheduler.service;
+package com.dove.stockcollection.application.service;
 
-import com.dove.krx.StockListing;
-import com.dove.krx.TradingDayPort;
 import com.dove.market.domain.enums.MarketType;
 import com.dove.stock.application.service.StockCommandService;
 import com.dove.stock.application.service.StockTagValueService;
 import com.dove.stock.domain.entity.Stock;
 import com.dove.stock.domain.enums.TagField;
+import com.dove.stockcollection.application.port.StockListing;
+import com.dove.stockcollection.application.port.TradingDayPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/domain/stock-collection/src/main/java/com/dove/stockcollection/domain/repository/CollectionTaskRepository.java
+++ b/domain/stock-collection/src/main/java/com/dove/stockcollection/domain/repository/CollectionTaskRepository.java
@@ -2,10 +2,14 @@ package com.dove.stockcollection.domain.repository;
 
 import com.dove.stockcollection.domain.entity.CollectionTask;
 import com.dove.stockcollection.domain.enums.CollectionStatus;
+import com.dove.stockcollection.domain.enums.CollectionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * COLLECTION_TASK 저장소.
@@ -14,4 +18,7 @@ import org.springframework.stereotype.Repository;
 public interface CollectionTaskRepository extends JpaRepository<CollectionTask, Long> {
     Page<CollectionTask> findByStatus(CollectionStatus status, Pageable pageable);
     Page<CollectionTask> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    List<CollectionTask> findAllByStatus(CollectionStatus status);
+    Optional<CollectionTask> findFirstByTypeInAndStatusOrderByCreatedAtAsc(List<CollectionType> types, CollectionStatus status);
+    boolean existsByTypeInAndStatus(List<CollectionType> types, CollectionStatus status);
 }

--- a/domain/stock-collection/src/test/java/com/dove/stockcollection/application/service/CollectionLauncherTest.java
+++ b/domain/stock-collection/src/test/java/com/dove/stockcollection/application/service/CollectionLauncherTest.java
@@ -37,8 +37,8 @@ class CollectionLauncherTest {
     void shouldCapToYesterdayWhenRangeIncludesToday() {
         when(taskService.create(any(), any(), any(), any(), any())).thenReturn(1L);
 
-        launcher.launchPriceCollection(StockExchange.KOSPI,
-                LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31), null, 7L); // to=오늘
+        launcher.enqueuePriceCollection(StockExchange.KOSPI,
+                LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31), 7L); // to=오늘
 
         // to 가 어제(5/30)로 캡되어 구조화 파라미터로 전달
         verify(taskService).create(eq(CollectionType.PRICE), eq(StockExchange.KOSPI),
@@ -47,8 +47,8 @@ class CollectionLauncherTest {
 
     @Test
     void shouldRejectWhenEntireRangeIsTodayOrFuture() {
-        assertThatThrownBy(() -> launcher.launchPriceCollection(StockExchange.KOSPI,
-                LocalDate.of(2026, 5, 31), LocalDate.of(2026, 6, 30), null, 7L))
+        assertThatThrownBy(() -> launcher.enqueuePriceCollection(StockExchange.KOSPI,
+                LocalDate.of(2026, 5, 31), LocalDate.of(2026, 6, 30), 7L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("INVALID_BACKFILL_RANGE");
 
@@ -56,37 +56,37 @@ class CollectionLauncherTest {
     }
 
     @Test
-    void shouldRelaunchPriceFromStructuredParamsWithFullAdjustedRefetch() {
+    void shouldReenqueuePriceFromStructuredParams() {
         CollectionTask source = new CollectionTask(CollectionType.PRICE, StockExchange.KOSDAQ,
                 LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), 7L);
         when(taskService.find(1L)).thenReturn(Optional.of(source));
         when(taskService.create(any(), any(), any(), any(), any())).thenReturn(99L);
 
-        launcher.relaunch(1L, 7L);
+        launcher.reenqueue(1L, 7L);
 
-        // 문자열 파싱 없이 구조화 컬럼(거래소·기간) 그대로 재실행
+        // 문자열 파싱 없이 구조화 컬럼(거래소·기간) 그대로 재등록
         verify(taskService).create(eq(CollectionType.PRICE), eq(StockExchange.KOSDAQ),
                 eq(LocalDate.of(2024, 1, 1)), eq(LocalDate.of(2024, 12, 31)), eq(7L));
     }
 
     @Test
-    void shouldRelaunchEventFromStructuredParams() {
+    void shouldReenqueueEventFromStructuredParams() {
         CollectionTask source = new CollectionTask(CollectionType.EVENT, null,
                 LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 31), 7L);
         when(taskService.find(2L)).thenReturn(Optional.of(source));
         when(taskService.create(any(), any(), any(), any(), any())).thenReturn(88L);
 
-        launcher.relaunch(2L, 7L);
+        launcher.reenqueue(2L, 7L);
 
         verify(taskService).create(eq(CollectionType.EVENT), eq(null),
                 eq(LocalDate.of(2023, 3, 1)), eq(LocalDate.of(2023, 3, 31)), eq(7L));
     }
 
     @Test
-    void shouldThrowWhenRelaunchSourceNotFound() {
+    void shouldThrowWhenReenqueueSourceNotFound() {
         when(taskService.find(404L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> launcher.relaunch(404L, 7L))
+        assertThatThrownBy(() -> launcher.reenqueue(404L, 7L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("TASK_NOT_FOUND");
     }

--- a/domain/stock-collection/src/test/java/com/dove/stockcollection/application/service/StockCollectionServiceTest.java
+++ b/domain/stock-collection/src/test/java/com/dove/stockcollection/application/service/StockCollectionServiceTest.java
@@ -1,7 +1,7 @@
 package com.dove.stockcollection.application.service;
 
-import com.dove.krx.StockListing;
-import com.dove.krx.TradingDayPort;
+import com.dove.stockcollection.application.port.StockListing;
+import com.dove.stockcollection.application.port.TradingDayPort;
 import com.dove.market.domain.enums.MarketType;
 import com.dove.stock.application.service.StockCommandService;
 import com.dove.stock.domain.entity.Stock;

--- a/domain/stock-collection/src/test/java/com/dove/stockcollection/application/service/StockSyncServiceTest.java
+++ b/domain/stock-collection/src/test/java/com/dove/stockcollection/application/service/StockSyncServiceTest.java
@@ -1,12 +1,12 @@
-package com.dove.scheduler.service;
+package com.dove.stockcollection.application.service;
 
-import com.dove.krx.StockListing;
-import com.dove.krx.TradingDayPort;
 import com.dove.market.domain.enums.MarketType;
 import com.dove.stock.application.service.StockCommandService;
 import com.dove.stock.application.service.StockTagValueService;
 import com.dove.stock.domain.entity.Stock;
 import com.dove.stock.domain.enums.TagField;
+import com.dove.stockcollection.application.port.StockListing;
+import com.dove.stockcollection.application.port.TradingDayPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/infrastructure/kis/src/main/java/com/dove/kis/config/RedissonConfig.java
+++ b/infrastructure/kis/src/main/java/com/dove/kis/config/RedissonConfig.java
@@ -4,6 +4,7 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 public class RedissonConfig {
 
     @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean(RedissonClient.class)
     public RedissonClient redissonClient(
             @Value("${spring.data.redis.host:127.0.0.1}") String host,
             @Value("${spring.data.redis.port:6379}") int port) {

--- a/infrastructure/krx/build.gradle
+++ b/infrastructure/krx/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     implementation project(':jpa')
+    implementation project(':stock-collection')
     implementation project(':concurrent')
     implementation project(':market')
     implementation project(':stock')

--- a/infrastructure/krx/src/main/java/com/dove/krx/acl/KrxListedStockTranslator.java
+++ b/infrastructure/krx/src/main/java/com/dove/krx/acl/KrxListedStockTranslator.java
@@ -1,6 +1,6 @@
 package com.dove.krx.acl;
 
-import com.dove.krx.StockListing;
+import com.dove.stockcollection.application.port.StockListing;
 import com.dove.krx.infrastructure.client.KrxListedStockItem;
 import com.dove.krx.infrastructure.client.KrxListedStockResponse;
 

--- a/infrastructure/krx/src/main/java/com/dove/krx/infrastructure/adapter/KrxTradingDayAdapter.java
+++ b/infrastructure/krx/src/main/java/com/dove/krx/infrastructure/adapter/KrxTradingDayAdapter.java
@@ -1,7 +1,7 @@
 package com.dove.krx.infrastructure.adapter;
 
-import com.dove.krx.StockListing;
-import com.dove.krx.TradingDayPort;
+import com.dove.stockcollection.application.port.StockListing;
+import com.dove.stockcollection.application.port.TradingDayPort;
 import com.dove.krx.acl.KrxListedStockTranslator;
 import com.dove.krx.infrastructure.client.KrxListedStockResponse;
 import com.dove.krx.infrastructure.client.KrxStockClient;

--- a/infrastructure/krx/src/test/java/com/dove/krx/acl/KrxListedStockTranslatorTest.java
+++ b/infrastructure/krx/src/test/java/com/dove/krx/acl/KrxListedStockTranslatorTest.java
@@ -1,6 +1,6 @@
 package com.dove.krx.acl;
 
-import com.dove.krx.StockListing;
+import com.dove.stockcollection.application.port.StockListing;
 import com.dove.krx.infrastructure.client.KrxListedStockItem;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/infrastructure/krx/src/test/java/com/dove/krx/infrastructure/adapter/KrxTradingDayAdapterTest.java
+++ b/infrastructure/krx/src/test/java/com/dove/krx/infrastructure/adapter/KrxTradingDayAdapterTest.java
@@ -1,6 +1,6 @@
 package com.dove.krx.infrastructure.adapter;
 
-import com.dove.krx.StockListing;
+import com.dove.stockcollection.application.port.StockListing;
 import com.dove.krx.infrastructure.client.KrxListedStockItem;
 import com.dove.krx.infrastructure.client.KrxListedStockResponse;
 import com.dove.krx.infrastructure.client.KrxStockClient;


### PR DESCRIPTION
- API는 PENDING 태스크 등록만, 실행은 PendingCollectionJob(30초 폴링, KRX/KIS 2트랙)이 담당
- 재기동 시 RUNNING → FAILED 자동 복구
- TradingDayPort·StockListing·StockSyncService를 krx 인프라 → stock-collection 도메인으로 이동
- api에서 :kis 제거, stock-collection에서 :krx 제거
- API 테스트: Redis·외부 포트 mock 등록으로 컨텍스트 로드 정상화