### PR TITLE
#47 리다이렉트 호스트를 X-Forwarded-Host 기준 절대 URL로 수정

### DIFF
--- a/web/src/app/api/auth/refresh-and-redirect/route.ts
+++ b/web/src/app/api/auth/refresh-and-redirect/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 import { NextRequest } from "next/server";
-import { relativeRedirect } from "@/utils/redirect";
+import { redirectTo } from "@/utils/redirect";
 
 const BASE               = process.env.INTERNAL_API_URL ?? "http://localhost:8081";
 const ACCESS_MAX_AGE     = 60 * 15;
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest) {
 
   const refreshToken = (await cookies()).get("refreshToken")?.value;
   if (!refreshToken) {
-    return relativeRedirect("/login");
+    return redirectTo(req, "/login");
   }
 
   const apiRes = await fetch(`${BASE}/auth/refresh`, {
@@ -30,14 +30,14 @@ export async function GET(req: NextRequest) {
   });
 
   if (!apiRes.ok) {
-    const res = relativeRedirect("/login");
+    const res = redirectTo(req, "/login");
     res.cookies.delete("token");
     res.cookies.set("refreshToken", "", { path: REFRESH_COOKIE_PATH, maxAge: 0 });
     return res;
   }
 
   const data = (await apiRes.json()) as { accessToken: string; refreshToken: string };
-  const res  = relativeRedirect(to);
+  const res  = redirectTo(req, to);
   res.cookies.set("token", data.accessToken, {
     httpOnly: true,
     secure:   process.env.NODE_ENV === "production",

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { decodeJwtPayload } from "@/utils/jwt";
-import { relativeRedirect } from "@/utils/redirect";
+import { redirectTo } from "@/utils/redirect";
 
 const PUBLIC_PATHS = ["/login", "/register"];
 
@@ -77,12 +77,12 @@ export function middleware(req: NextRequest) {
   if (!valid && !isPublic) {
     // refresh token 경유 갱신 시도 → 성공 시 원래 경로, 실패 시 /login
     const to = req.nextUrl.pathname + req.nextUrl.search;
-    const res = relativeRedirect(`/api/auth/refresh-and-redirect?to=${encodeURIComponent(to)}`);
+    const res = redirectTo(req, `/api/auth/refresh-and-redirect?to=${encodeURIComponent(to)}`);
     if (tokenCookie) res.cookies.delete("token"); // 만료 토큰 즉시 제거
     return res;
   }
   if (valid && req.nextUrl.pathname === "/login") {
-    return relativeRedirect("/");
+    return redirectTo(req, "/");
   }
   const res = NextResponse.next();
   res.headers.set("x-pathname", req.nextUrl.pathname);

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -1,14 +1,16 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
- * 같은 오리진 내부 경로로 상대 Location 리다이렉트 응답을 만든다.
+ * 프록시가 넘긴 실제 호스트 기준으로 절대 URL 리다이렉트 응답을 만든다.
  *
- * standalone 서버가 절대 URL 호스트를 바인딩 주소(0.0.0.0)로 잡는 문제를 피한다.
+ * standalone 서버는 req.url 호스트를 바인딩 주소(0.0.0.0)로 잡으므로,
+ * X-Forwarded-Host / Host 헤더의 실제 호스트로 URL을 구성한다.
  *
+ * @param req  현재 요청 (호스트·프로토콜 헤더 출처)
  * @param path "/"로 시작하는 내부 경로(쿼리 포함 가능)
  */
-export function relativeRedirect(path: string): NextResponse {
-  const res = new NextResponse(null, { status: 307 });
-  res.headers.set("Location", path);
-  return res;
+export function redirectTo(req: NextRequest, path: string): NextResponse {
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? req.nextUrl.host;
+  const proto = req.headers.get("x-forwarded-proto") ?? req.nextUrl.protocol.replace(":", "");
+  return NextResponse.redirect(new URL(path, `${proto}://${host}`));
 }


### PR DESCRIPTION
미들웨어가 상대 Location을 내부에서 new URL()로 재파싱하다 ERR_INVALID_URL로 실패하던 회귀 수정. req.url의 0.0.0.0 대신 프록시가 넘긴 실제 호스트로
절대 URL을 구성한다.